### PR TITLE
Adding support for NetCDF

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,10 @@ Oh, and it can also handle PDFs (with
 Word Documents (read-only, with [Antiword](http://www.winfield.demon.nl/)),
 and Mac OS X plist files.
 
+If you are more scientifically inclined it also lets you edit
+[NetCDF](http://www.opengeospatial.org/standards/netcdf) files in their
+CDL form.
+
 Installation
 ------------
 

--- a/doc/afterimage.txt
+++ b/doc/afterimage.txt
@@ -19,6 +19,9 @@ Word documents have their text extracted (one way) with antiword.
 
 OS X binary plists are converted to/from XML with plutil.
 
+NetCDF files are converted to CDL with ncdump for editing and back to NetCDF
+with ncgen
+
 CUSTOMIZATION                                   *afterimage-customization*
 
 The easiest way to provide custom handlers is to learn from the source to the

--- a/plugin/afterimage.vim
+++ b/plugin/afterimage.vim
@@ -21,6 +21,13 @@ augroup afterimage
     autocmd BufWriteCmd,FileWriteCmd  *.ico call AfterimageWriteCmd("convert %s ico:%s")
   endif
 
+  " Convert NetCDF files to cdl for editing (http://www.unidata.ucar.edu/software/netcdf/)
+  if !exists("#BufWriteCmd#*.nc")
+    autocmd BufReadPre,FileReadPre    *.nc setlocal bin
+    autocmd BufReadPost,FileReadPost  *.nc if AfterimageReadPost("ncdump %s >%s") | set ft=c | endif
+    autocmd BufWriteCmd,FileWriteCmd  *.nc call AfterimageWriteCmd("cat %s | ncgen -o %s")
+  endif
+
   if !exists("#BufWriteCmd#*.pdf")
     autocmd BufReadPre,FileReadPre    *.pdf setlocal bin
     autocmd BufReadPost,FileReadPost  *.pdf call AfterimageReadPost("pdftk %s output %s uncompress")


### PR DESCRIPTION
[NetCDF](http://en.wikipedia.org/wiki/NetCDF) is a binary data format used generally for storing array based scientific data. It has tools to decode and encode it to a text representation (CDL) so this change allows editing of the binary files from a text editor.

I realise that this is a little off topic for the original image editing use of this plugin but fits very easily into the framework that is there so I thought that it was nicer to add it to this plugin rather than creating a new one. Let me know if you don't want to pull this in and I'll see about creating my own plugin.
